### PR TITLE
Don't force upgrades

### DIFF
--- a/lambdas/build_lambda.py
+++ b/lambdas/build_lambda.py
@@ -34,7 +34,7 @@ def install_dependencies(path):
     """ Install required modules to dependencies folder """
     subprocess.check_call(
         [
-            sys.executable, '-m', 'pip', 'install', '--compile', '-U', '-r',
+            sys.executable, '-m', 'pip', 'install', '--compile', '-r',
             os.path.join(path, 'requirements.txt'), '-t', os.path.join(path, 'dependencies')
         ],
         cwd=path


### PR DESCRIPTION
This was causing issues with build_lambda overwriting custom dependencies if they had the same name as something in requirements.txt.