### PR TITLE
Fixed, create the account arn correctly.

### DIFF
--- a/cloudformation/tropo/templates/hyp3_kms_key.py
+++ b/cloudformation/tropo/templates/hyp3_kms_key.py
@@ -20,7 +20,7 @@ key_policy = PolicyDocument(
             Effect=Allow,
             Principal=Principal(
                 "AWS", [
-                    Join(":", ["arn:aws:iam", Ref(AWS_ACCOUNT_ID)])
+                    Join(":", ["arn:aws:iam:", Ref(AWS_ACCOUNT_ID)])
                 ]
             ),
             Action=[Action("kms", "*")],


### PR DESCRIPTION
Arn needs two colons between iam and the account id