### PR TITLE
HIB-31 Update EB in CI **Merge at your own risk!**

### DIFF
--- a/cloudformation/tropo/templates/hyp3_api_eb.py
+++ b/cloudformation/tropo/templates/hyp3_api_eb.py
@@ -48,8 +48,6 @@ from .hyp3_vpc import get_public_subnets, hyp3_vpc
 from .utils import get_map
 from .hyp3_keypairname_param import keyname
 
-source_zip = "hyp3_api.zip"
-
 
 print('  adding api_eb')
 
@@ -101,7 +99,7 @@ app_version = t.add_resource(ApplicationVersion(
         S3Bucket=environment.eb_bucket,
         S3Key="{maturity}/{zip}".format(
             maturity=environment.maturity,
-            zip=source_zip
+            zip=environment.hyp3_api_source_zip
         )
     )
 ))

--- a/cloudformation/tropo/tropo_env.py
+++ b/cloudformation/tropo/tropo_env.py
@@ -19,6 +19,7 @@ class Environment:
         self.maturity = "test"
 
         self.set_lambda_version_variables()
+        self.hyp3_api_source_zip = "hyp3_api.zip"
 
         self.use_name_parameters = True
         self.should_create_db = True


### PR DESCRIPTION
Creates a uniquely named zip file (of hyp3 api source code) for each CI run. Sadly ElasticBeanstalk does not support S3 Object version ids.