### PR TITLE
HIB 91 - scheduler puts jobs in queue

### DIFF
--- a/cloudformation/tropo/templates/hyp3_scheduler.py
+++ b/cloudformation/tropo/templates/hyp3_scheduler.py
@@ -34,6 +34,7 @@ from . import utils
 from .hyp3_db_params import db_name, db_pass, db_user
 from .hyp3_kms_key import kms_key
 from .hyp3_sns import finish_sns
+from .hyp3_sqs import start_events
 
 source_zip = "scheduler.zip"
 
@@ -74,8 +75,10 @@ scheduler = utils.make_lambda_function(
                 'DB_HOST': utils.get_host_address(),
                 'DB_USER': Ref(db_user),
                 'DB_PASSWORD': Ref(db_pass),
-                'DB_NAME': Ref(db_name)
-            }),
+                'DB_NAME': Ref(db_name),
+                'QUEUE_URL': Ref(start_events)
+            }
+        ),
         "KmsKeyArn": GetAtt(kms_key, "Arn"),
         "MemorySize": 128,
         "Timeout": 300

--- a/lambdas/scheduler/Pipfile
+++ b/lambdas/scheduler/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 "3da5cae" = {path = "./../../modules/hyp3_db"}
 "61ea59b" = {path = "./../../modules/hyp3_events"}
-botocore = "*"
+"boto3" = "*"
 
 [dev-packages]
 pytest = "*"

--- a/lambdas/scheduler/Pipfile
+++ b/lambdas/scheduler/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 "3da5cae" = {path = "./../../modules/hyp3_db"}
 "61ea59b" = {path = "./../../modules/hyp3_events"}
+botocore = "*"
 
 [dev-packages]
 pytest = "*"

--- a/lambdas/scheduler/Pipfile
+++ b/lambdas/scheduler/Pipfile
@@ -6,7 +6,6 @@ name = "pypi"
 [packages]
 "3da5cae" = {path = "./../../modules/hyp3_db"}
 "61ea59b" = {path = "./../../modules/hyp3_events"}
-"boto3" = "*"
 
 [dev-packages]
 pytest = "*"

--- a/lambdas/scheduler/requirements.dev.txt
+++ b/lambdas/scheduler/requirements.dev.txt
@@ -1,19 +1,19 @@
 -i https://pypi.org/simple
 atomicwrites==1.1.5
 attrs==18.1.0
-boto3==1.7.54
-botocore==1.10.54
+boto3==1.7.72
+botocore==1.10.72
 coverage==4.5.1
 docutils==0.14
-hypothesis==3.66.1
+hypothesis==3.66.30
 jmespath==0.9.3
 mock==2.0.0
-more-itertools==4.2.0
-pbr==4.1.0
-pluggy==0.6.0
+more-itertools==4.3.0
+pbr==4.2.0
+pluggy==0.7.1
 py==1.5.4
 pytest-cov==2.5.1
-pytest==3.6.3
+pytest==3.7.1
 python-dateutil==2.7.3; python_version >= '2.7'
 s3transfer==0.1.13
 six==1.11.0

--- a/lambdas/scheduler/src/dispatch/__init__.py
+++ b/lambdas/scheduler/src/dispatch/__init__.py
@@ -1,15 +1,1 @@
-from typing import List
-
-from schedule import Job
-
-from . import scheduler_sns as sns
-
-
-def send_all_events(new_hyp3_events: List[Job]) -> None:
-    print(f'Dispatching {len(new_hyp3_events)} events')
-
-    for event in new_hyp3_events:
-        sns.push_event(event)
-
-
-__all__ = ['send_all_events']
+from .send_all_events import all_events

--- a/lambdas/scheduler/src/dispatch/scheduler_sqs.py
+++ b/lambdas/scheduler/src/dispatch/scheduler_sqs.py
@@ -1,0 +1,5 @@
+from hyp3_events import StartEvent
+
+
+def add_event(event: StartEvent):
+    print('adding start event to queue')

--- a/lambdas/scheduler/src/dispatch/scheduler_sqs.py
+++ b/lambdas/scheduler/src/dispatch/scheduler_sqs.py
@@ -1,5 +1,30 @@
+import boto3
 from hyp3_events import StartEvent
 
+from scheduler_env import environment
 
-def add_event(event: StartEvent):
+
+sqs = boto3.client('sqs')
+
+
+def add_event(event: StartEvent) -> None:
     print('adding start event to queue')
+
+    send(
+        event_type=event.event_type,
+        body=event.to_json()
+    )
+
+
+def send(event_type: str, body: str) -> None:
+    sqs.send_message(
+        QueueUrl=environment.queue_url,
+        MessageBody=body,
+        MessageAttributes={
+            'EventType': {
+                'StringValue': event_type,
+                'DataType': 'String'
+            }
+        },
+        MessageGroupId='1'
+    )

--- a/lambdas/scheduler/src/dispatch/send_all_events.py
+++ b/lambdas/scheduler/src/dispatch/send_all_events.py
@@ -1,0 +1,16 @@
+from typing import List
+
+from hyp3_events import Hyp3Event
+
+from . import scheduler_sns as sns
+from . import scheduler_sqs as sqs
+
+
+def all_events(new_hyp3_events: List[Hyp3Event]) -> None:
+    print(f'Dispatching {len(new_hyp3_events)} events')
+
+    for event in new_hyp3_events:
+        if 'Email' in event.event_type:
+            sns.push_event(event)
+        else:
+            sqs.add_event(event)

--- a/lambdas/scheduler/src/dispatch/send_all_events.py
+++ b/lambdas/scheduler/src/dispatch/send_all_events.py
@@ -14,3 +14,5 @@ def all_events(new_hyp3_events: List[Hyp3Event]) -> None:
             sns.push_event(event)
         else:
             sqs.add_event(event)
+
+    print('Done!')

--- a/lambdas/scheduler/src/events/make.py
+++ b/lambdas/scheduler/src/events/make.py
@@ -8,13 +8,26 @@ from schedule import Job
 # Add implementation for conversion from Job type
 EmailEvent.impl_from(
     Job,
-    lambda obj: EmailEvent(
-        user_id=obj.user.id,
-        sub_id=obj.sub.id,
+    lambda job: EmailEvent(
+        user_id=job.user.id,
+        sub_id=job.sub.id,
         additional_info=[],
-        browse_url=obj.granule.browse_url,
-        download_url=obj.granule.download_url,
-        granule_name=obj.granule.name
+        browse_url=job.granule.browse_url,
+        download_url=job.granule.download_url,
+        granule_name=job.granule.name
+    )
+)
+
+StartEvent.impl_from(
+    Job,
+    lambda job: StartEvent(
+        granule=job.granule.name,
+        user_id=job.user.id,
+        sub_id=job.sub.id,
+        # TODO: Add output patterns from process here.
+        output_patterns=[],
+        script_path=job.process.script,
+        additional_info=[]
     )
 )
 
@@ -36,7 +49,7 @@ def make_new_granule_events_with(
 def make_from(jobs: List[Job]) -> List[Hyp3Event]:
     """ make email packages into notify only events
 
-        :param list(tuple): email packages of the form schedule.Job(sub, user, granule)
+        :param list(Job): jobs to make into events
 
         :returns: hyp3 events corresponding to each package
         :rtype: list[hyp3_events.EmailEvent]
@@ -48,7 +61,7 @@ def make_from(jobs: List[Job]) -> List[Hyp3Event]:
 
 def _make_event(job: Job) -> Hyp3Event:
     # NOTE: Scheduler relies on Notify Only being process 1
-    if job.sub.process_id == 1:
+    if 'notify' in job.process.name.lower():
         return EmailEvent.from_type(job)
 
     return StartEvent.from_type(job)

--- a/lambdas/scheduler/src/events/make.py
+++ b/lambdas/scheduler/src/events/make.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+import json
 
 from hyp3_events import EmailEvent, Hyp3Event, NewGranuleEvent, StartEvent
 
@@ -18,11 +19,16 @@ EmailEvent.impl_from(
 )
 
 
-def make_new_granule_events_with(new_granule_dicts: List[Dict[str, Any]]) -> List[NewGranuleEvent]:
+def make_new_granule_events_with(
+        new_granule_dicts: List[Dict[str, Any]]
+) -> List[NewGranuleEvent]:
     events = [
         NewGranuleEvent(**event)
         for event in new_granule_dicts
     ]
+
+    print('Scheduling hyp3_jobs')
+    print(json.dumps([g.name for g in events]))
 
     return events
 

--- a/lambdas/scheduler/src/events/make.py
+++ b/lambdas/scheduler/src/events/make.py
@@ -60,8 +60,7 @@ def make_from(jobs: List[Job]) -> List[Hyp3Event]:
 
 
 def _make_event(job: Job) -> Hyp3Event:
-    # NOTE: Scheduler relies on Notify Only being process 1
-    if 'notify' in job.process.name.lower():
+    if job.is_notify_only():
         return EmailEvent.from_type(job)
 
     return StartEvent.from_type(job)

--- a/lambdas/scheduler/src/lambda_function.py
+++ b/lambdas/scheduler/src/lambda_function.py
@@ -23,3 +23,4 @@ def set_environment_variables():
     ]
 
     environment.sns_arn = os.environ['SNS_ARN']
+    environment.queue_url = os.environ['QUEUE_URL']

--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -14,6 +14,9 @@ class Job(NamedTuple):
     user: User
     granule: NewGranuleEvent
 
+    def is_notify_only(self):
+        return 'notify' in self.process.name.lower()
+
 
 def hyp3_jobs(new_granules):
     """ Get all the hyp3 jobs from the new granules

--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -32,7 +32,6 @@ def hyp3_jobs(new_granules):
         jobs = flatten_list(jobs_for_each_granule)
 
         print('Found {} jobs to start'.format(len(jobs)))
-        print('Making notify only events')
 
         return jobs
 

--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -1,7 +1,7 @@
 from typing import NamedTuple
 
 import hyp3_db
-from hyp3_db.hyp3_models import Subscription, User
+from hyp3_db.hyp3_models import Subscription, User, Process
 from hyp3_events import NewGranuleEvent
 from scheduler_env import environment
 
@@ -10,6 +10,7 @@ from . import queries
 
 class Job(NamedTuple):
     sub: Subscription
+    process: Process
     user: User
     granule: NewGranuleEvent
 
@@ -45,9 +46,11 @@ def get_jobs_for(granule, db):
     print('Found {} subs overlapping granule'.format(len(subs)))
 
     users = get_users_for(subs, db)
+    processes = get_processes(db)
 
     return [
-        Job(sub, users[sub.user_id], granule) for sub in subs
+        Job(sub, processes[sub.process_id], users[sub.user_id], granule)
+        for sub in subs
     ]
 
 
@@ -69,8 +72,18 @@ def get_users_for(subs, db):
 
     users = queries.get_users_by_ids(db, user_ids)
 
+    return dict_indexed_by_id(users)
+
+
+def get_processes(db):
+    processes = queries.get_processes(db)
+
+    return dict_indexed_by_id(processes)
+
+
+def dict_indexed_by_id(objs):
     return {
-        user.id: user for user in users
+        obj.id: obj for obj in objs
     }
 
 

--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -31,6 +31,9 @@ def hyp3_jobs(new_granules):
 
         jobs = flatten_list(jobs_for_each_granule)
 
+        print('Found {} jobs to start'.format(len(jobs)))
+        print('Making notify only events')
+
         return jobs
 
 

--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -25,14 +25,14 @@ def hyp3_jobs(new_granules):
     host, name, password, db = environment.db_creds
 
     with hyp3_db.connect(host, name, password, db) as db:
+        print('finding jobs for each granule')
         jobs_for_each_granule = [
             get_jobs_for(granule, db) for granule in new_granules
         ]
 
         jobs = flatten_list(jobs_for_each_granule)
 
-        print('Found {} jobs to start'.format(len(jobs)))
-        print('Making notify only events')
+        print('Found {} total jobs to start'.format(len(jobs)))
 
         return jobs
 

--- a/lambdas/scheduler/src/schedule/queries.py
+++ b/lambdas/scheduler/src/schedule/queries.py
@@ -1,5 +1,5 @@
 
-from hyp3_db.hyp3_models import Subscription, User
+from hyp3_db.hyp3_models import Subscription, User, Process
 from geoalchemy2 import WKTElement
 
 
@@ -39,3 +39,8 @@ def get_enabled_intersecting_subs(db, polygon):
         .all()
 
     return intersecting_subs
+
+
+def get_processes(db):
+    return db.session.query(Process) \
+        .all()

--- a/lambdas/scheduler/src/schedule/queries.py
+++ b/lambdas/scheduler/src/schedule/queries.py
@@ -34,7 +34,8 @@ def get_enabled_intersecting_subs(db, polygon):
     intersecting = Subscription.location.intersects(poly)
 
     intersecting_subs = db.session.query(Subscription) \
-        .filter_by(enabled=True) \
+        .filter(Subscription.enabled == True) \
+        .filter(Subscription.process.has(enabled=True)) \
         .filter(intersecting) \
         .all()
 

--- a/lambdas/scheduler/src/scheduler_env.py
+++ b/lambdas/scheduler/src/scheduler_env.py
@@ -8,6 +8,7 @@ class Environment:
         ]
 
         self.sns_arn = None
+        self.queue_url = None
         self.maturity = 'test'
 
 

--- a/lambdas/scheduler/src/scheduler_main.py
+++ b/lambdas/scheduler/src/scheduler_main.py
@@ -1,17 +1,18 @@
-
 import json
 from typing import Dict
 
-import dispatch
 import events
 import schedule
+import dispatch
 
 
-def scheduler(event: Dict) -> None:
+def scheduler(aws_event: Dict) -> None:
     """ Wrapper around scheduler lambda that can be imported by pytest."""
+    print(json.dumps(aws_event))
 
-    granules = event['new_granules']
-    new_granule_events = events.make_new_granule_events_with(granules)
+    new_granule_events = events.make_new_granule_events_with(
+        aws_event['new_granuless']
+    )
 
     jobs = schedule.hyp3_jobs(new_granule_events)
 

--- a/lambdas/scheduler/src/scheduler_main.py
+++ b/lambdas/scheduler/src/scheduler_main.py
@@ -11,7 +11,7 @@ def scheduler(aws_event: Dict) -> None:
     print(json.dumps(aws_event))
 
     new_granule_events = events.make_new_granule_events_with(
-        aws_event['new_granuless']
+        aws_event['new_granules']
     )
 
     jobs = schedule.hyp3_jobs(new_granule_events)

--- a/lambdas/scheduler/src/scheduler_main.py
+++ b/lambdas/scheduler/src/scheduler_main.py
@@ -16,6 +16,9 @@ def scheduler(aws_event: Dict) -> None:
 
     jobs = schedule.hyp3_jobs(new_granule_events)
 
+    if not jobs:
+        return
+
     new_hyp3_events = events.make_from(jobs)
 
     dispatch.all_events(new_hyp3_events)

--- a/lambdas/scheduler/src/scheduler_main.py
+++ b/lambdas/scheduler/src/scheduler_main.py
@@ -24,6 +24,6 @@ def scheduler(event: Dict) -> None:
 
     print('Sending {} new events'.format(len(new_hyp3_events)))
 
-    dispatch.send_all_events(new_hyp3_events)
+    dispatch.all_events(new_hyp3_events)
 
     print('Done!')

--- a/lambdas/scheduler/src/scheduler_main.py
+++ b/lambdas/scheduler/src/scheduler_main.py
@@ -9,21 +9,12 @@ import schedule
 
 def scheduler(event: Dict) -> None:
     """ Wrapper around scheduler lambda that can be imported by pytest."""
+
     granules = event['new_granules']
     new_granule_events = events.make_new_granule_events_with(granules)
 
-    print('Scheduling hyp3_jobs')
-    print(json.dumps([g.name for g in new_granule_events]))
+    jobs = schedule.hyp3_jobs(new_granule_events)
 
-    job_packages = schedule.hyp3_jobs(new_granule_events)
-
-    print('Found {} jobs to start'.format(len(job_packages)))
-    print('Making notify only events')
-
-    new_hyp3_events = events.make_from(job_packages)
-
-    print('Sending {} new events'.format(len(new_hyp3_events)))
+    new_hyp3_events = events.make_from(jobs)
 
     dispatch.all_events(new_hyp3_events)
-
-    print('Done!')

--- a/lambdas/scheduler/tests/conftest.py
+++ b/lambdas/scheduler/tests/conftest.py
@@ -1,0 +1,41 @@
+import pathlib as pl
+import json
+
+import pytest
+
+import hyp3_events
+from hyp3_db import hyp3_models
+import import_scheduler
+from schedule import Job
+
+data_path = pl.Path(__file__).parent / 'data'
+
+
+@pytest.fixture
+def granule_events(testing_granules):
+    return [
+        hyp3_events.NewGranuleEvent(**e) for e in
+        testing_granules['new_granules']
+    ]
+
+
+@pytest.fixture
+def testing_granules():
+    new_grans_path = data_path / 'new_granules.json'
+
+    with new_grans_path.open('r') as f:
+        return json.load(f)
+
+
+def format_packages(packages):
+    return [format_package(package) for package in packages]
+
+
+def format_package(pack):
+    sub, user, granule = pack
+
+    return Job(
+        hyp3_models.Subscription(**sub),
+        hyp3_models.User(**user),
+        hyp3_events.NewGranuleEvent(**granule)
+    )

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -1,0 +1,3 @@
+
+def test_dispatch():
+    pass

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -18,14 +18,16 @@ from scheduler_env import environment as env
 class FakeEvent(NamedTuple):
     event_type: str
 
+EMAIL_EVENTS_COUNT, START_EVENTS_COUNT = 10, 5
+
 
 @mock.patch('dispatch.scheduler_sqs.add_event')
 @mock.patch('dispatch.scheduler_sns.push_event')
 def test_dispatch(sns_mock, sqs_mock, events):
     dispatch.all_events(events)
 
-    assert sns_mock.call_count == 10
-    assert sqs_mock.call_count == 5
+    assert sns_mock.call_count == EMAIL_EVENTS_COUNT
+    assert sqs_mock.call_count == START_EVENTS_COUNT
 
 
 def test_sqs_add(start_event):
@@ -44,8 +46,8 @@ def test_sqs_add(start_event):
 @pytest.fixture
 def events():
     return  \
-        [FakeEvent('EmailEvent') for _ in range(10)] + \
-        [FakeEvent('StartEvent') for _ in range(5)]
+        [FakeEvent('EmailEvent') for _ in range(EMAIL_EVENTS_COUNT)] + \
+        [FakeEvent('StartEvent') for _ in range(START_EVENTS_COUNT)]
 
 
 @pytest.fixture
@@ -82,5 +84,5 @@ def queue():
         sqs_client.delete_queue(QueueUrl=queue.url)
 
 
-def randomness(N):
+def unique_id(N):
     return ''.join(random.choices(string.ascii_uppercase + string.digits, k=N))

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -1,10 +1,18 @@
+import contextlib
 from typing import NamedTuple
+import random
+import string
 
+import boto3
 import pytest
 import mock
 
+import hyp3_events
+
 import import_scheduler
 import dispatch
+from dispatch import scheduler_sqs as sqs
+from scheduler_env import environment as env
 
 
 class FakeEvent(NamedTuple):
@@ -20,8 +28,56 @@ def test_dispatch(sns_mock, sqs_mock, events):
     assert sqs_mock.call_count == 5
 
 
+def test_sqs_add(start_event):
+    with queue() as q:
+        env.queue_url = q.url
+        sqs.add_event(start_event)
+
+        messages = q.receive_messages(MessageAttributeNames=['EventType'])
+        assert len(messages) == 1
+
+        event_from_queue = hyp3_events.StartEvent.from_json(messages[0].body)
+
+        assert event_from_queue == start_event
+
+
 @pytest.fixture
 def events():
     return  \
         [FakeEvent('EmailEvent') for _ in range(10)] + \
         [FakeEvent('StartEvent') for _ in range(5)]
+
+
+@pytest.fixture
+def start_event():
+    return hyp3_events.StartEvent(
+        granule=('S1A_IW_GRDH_1SDV_20180803T125353_'
+                 '20180803T125418_023082_02819A_1DBD'),
+        user_id=1,
+        sub_id=1,
+        output_patterns=['*/*.txt'],
+        script_path='',
+        additional_info=[]
+    )
+
+
+@contextlib.contextmanager
+def queue():
+    sqs_resource = boto3.resource('sqs')
+    sqs_client = boto3.client('sqs')
+
+    queue = sqs_resource.create_queue(
+        QueueName='test' + randomness(4) + '.fifo',
+        Attributes={
+            'FifoQueue': 'true',
+            'ContentBasedDeduplication': 'true'
+        }
+    )
+
+    yield queue
+
+    sqs_client.delete_queue(QueueUrl=queue.url)
+
+
+def randomness(N):
+    return ''.join(random.choices(string.ascii_uppercase + string.digits, k=N))

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -74,9 +74,12 @@ def queue():
         }
     )
 
-    yield queue
-
-    sqs_client.delete_queue(QueueUrl=queue.url)
+    try:
+        yield queue
+    except Exception:
+        pass
+    finally:
+        sqs_client.delete_queue(QueueUrl=queue.url)
 
 
 def randomness(N):

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -15,9 +15,6 @@ from dispatch import scheduler_sqs as sqs
 from scheduler_env import environment as env
 
 
-class FakeEvent(NamedTuple):
-    event_type: str
-
 EMAIL_EVENTS_COUNT, START_EVENTS_COUNT = 10, 5
 
 
@@ -41,6 +38,10 @@ def test_sqs_add(start_event):
         event_from_queue = hyp3_events.StartEvent.from_json(messages[0].body)
 
         assert event_from_queue == start_event
+
+
+class FakeEvent(NamedTuple):
+    event_type: str
 
 
 @pytest.fixture
@@ -69,7 +70,7 @@ def queue():
     sqs_client = boto3.client('sqs')
 
     queue = sqs_resource.create_queue(
-        QueueName='test' + randomness(4) + '.fifo',
+        QueueName=f'test{unique_id(4)}.fifo',
         Attributes={
             'FifoQueue': 'true',
             'ContentBasedDeduplication': 'true'

--- a/lambdas/scheduler/tests/test_dispatch.py
+++ b/lambdas/scheduler/tests/test_dispatch.py
@@ -1,3 +1,27 @@
+from typing import NamedTuple
 
-def test_dispatch():
-    pass
+import pytest
+import mock
+
+import import_scheduler
+import dispatch
+
+
+class FakeEvent(NamedTuple):
+    event_type: str
+
+
+@mock.patch('dispatch.scheduler_sqs.add_event')
+@mock.patch('dispatch.scheduler_sns.push_event')
+def test_dispatch(sns_mock, sqs_mock, events):
+    dispatch.all_events(events)
+
+    assert sns_mock.call_count == 10
+    assert sqs_mock.call_count == 5
+
+
+@pytest.fixture
+def events():
+    return  \
+        [FakeEvent('EmailEvent') for _ in range(10)] + \
+        [FakeEvent('StartEvent') for _ in range(5)]

--- a/lambdas/scheduler/tests/test_events.py
+++ b/lambdas/scheduler/tests/test_events.py
@@ -21,13 +21,3 @@ def test_make_new_granule_events(granule_events):
     assert all([
         isinstance(e, hyp3_events.NewGranuleEvent) for e in new_granule_events
     ])
-
-
-def test_events():
-    packages = utils.load_email_packages()
-
-    new_events = events.make_from(packages)
-
-    assert isinstance(new_events, list)
-    for event in new_events:
-        assert isinstance(event, hyp3_events.Hyp3Event)

--- a/lambdas/scheduler/tests/test_scheduler.py
+++ b/lambdas/scheduler/tests/test_scheduler.py
@@ -13,20 +13,14 @@ import scheduler_main
 
 @skip_if_creds_not_available
 @mock.patch('dispatch.sns.push')
-def test_scheduler_main(sns_mock):
-    event = utils.load_testing_granules()
-
-    scheduler_main.scheduler(event)
+def test_scheduler_main(sns_mock, testing_granules):
+    scheduler_main.scheduler(testing_granules)
 
     sns_mock.assert_called()
 
 
 @skip_if_creds_not_available
-def test_scheduler():
-    granules = utils.load_testing_granules()['new_granules']
-    granule_events = [
-        hyp3_events.NewGranuleEvent(**e) for e in granules
-    ]
+def test_scheduler(granule_events):
     email_packages = schedule.hyp3_jobs(granule_events)
 
     assert isinstance(email_packages, list)

--- a/lambdas/scheduler/tests/test_scheduler.py
+++ b/lambdas/scheduler/tests/test_scheduler.py
@@ -12,8 +12,9 @@ import scheduler_main
 
 
 @skip_if_creds_not_available
+@mock.patch('dispatch.scheduler_sqs.add_event')
 @mock.patch('dispatch.scheduler_sns.push')
-def test_scheduler_main(sns_mock, testing_granules):
+def test_scheduler_main(sns_mock, sqs_mock, testing_granules):
     scheduler_main.scheduler(testing_granules)
 
     sns_mock.assert_called()

--- a/lambdas/scheduler/tests/test_scheduler.py
+++ b/lambdas/scheduler/tests/test_scheduler.py
@@ -12,7 +12,7 @@ import scheduler_main
 
 
 @skip_if_creds_not_available
-@mock.patch('dispatch.sns.push')
+@mock.patch('dispatch.scheduler_sns.push')
 def test_scheduler_main(sns_mock, testing_granules):
     scheduler_main.scheduler(testing_granules)
 

--- a/lambdas/scheduler/tests/test_scheduler.py
+++ b/lambdas/scheduler/tests/test_scheduler.py
@@ -12,8 +12,8 @@ import scheduler_main
 
 
 @skip_if_creds_not_available
-@mock.patch('dispatch.scheduler_sqs.add_event')
 @mock.patch('dispatch.scheduler_sns.push')
+@mock.patch('dispatch.scheduler_sqs.add_event')
 def test_scheduler_main(sns_mock, sqs_mock, testing_granules):
     scheduler_main.scheduler(testing_granules)
 
@@ -22,14 +22,15 @@ def test_scheduler_main(sns_mock, sqs_mock, testing_granules):
 
 @skip_if_creds_not_available
 def test_scheduler(granule_events):
-    email_packages = schedule.hyp3_jobs(granule_events)
+    jobs = schedule.hyp3_jobs(granule_events)
 
-    assert isinstance(email_packages, list)
+    assert isinstance(jobs, list)
 
-    for sub, user, granule_event in email_packages:
-        assert hasattr(sub, 'id')
-        assert isinstance(granule_event, hyp3_events.NewGranuleEvent)
-        assert sub.user_id == user.id
+    for job in jobs:
+        assert hasattr(job.sub, 'id')
+        assert isinstance(job.granule, hyp3_events.NewGranuleEvent)
+        assert job.sub.user_id == job.user.id
+        assert job.process
 
     if 'local' in environment.maturity:
-        utils.cache_results(email_packages)
+        utils.cache_results(jobs)

--- a/lambdas/scheduler/tests/testing_utils.py
+++ b/lambdas/scheduler/tests/testing_utils.py
@@ -1,12 +1,6 @@
 import json
-import pathlib as pl
 
-import hyp3_events
-from hyp3_db import hyp3_models
-
-from schedule import Job
-
-data_path = pl.Path(__file__).parent / 'data'
+from conftest import data_path
 
 
 def cache_results(email_packages):
@@ -30,33 +24,3 @@ def serializeable(sub):
         sub_dict[k] = v
 
     return sub_dict
-
-
-def load_testing_granules():
-    new_grans_path = data_path / 'new_granules.json'
-
-    with new_grans_path.open('r') as f:
-        return json.load(f)
-
-
-def load_email_packages():
-    email_packages_path = data_path / 'email-packages.json'
-
-    with email_packages_path.open('r') as f:
-        unformatted_packages = json.load(f)
-
-    return format_packages(unformatted_packages)
-
-
-def format_packages(packages):
-    return [format_package(package) for package in packages]
-
-
-def format_package(pack):
-    sub, user, granule = pack
-
-    return Job(
-        hyp3_models.Subscription(**sub),
-        hyp3_models.User(**user),
-        hyp3_events.NewGranuleEvent(**granule)
-    )

--- a/lambdas/setup_db/tests/test_setup_db.py
+++ b/lambdas/setup_db/tests/test_setup_db.py
@@ -53,9 +53,9 @@ def check_new_user(db, mock_env):
 
 
 def check_processes(db, mock_env):
-    notify_only = db.session.query(hyp3_models.Process).one()
+    processes = db.session.query(hyp3_models.Process).all()
 
-    assert notify_only.name == 'Notify Only'
+    assert set(p.name for p in processes) == {'Notify Only', 'RTC Snap'}
 
 
 def check_setup_db_still_works(sample_event):

--- a/modules/hyp3_db/src/hyp3_db/hyp3_models/processes.py
+++ b/modules/hyp3_db/src/hyp3_db/hyp3_models/processes.py
@@ -3,6 +3,7 @@
 # Created June 7, 2017
 
 from sqlalchemy import Boolean, Column, Float, Integer, Text, sql
+from sqlalchemy.dialects.postgresql import JSON
 
 from .base import Base
 
@@ -26,6 +27,10 @@ class Process(Base):
     ami_id = Column(Text, nullable=False)
     ec2_size = Column(Text, nullable=False)
 
+    output_patterns = Column(
+        JSON,
+        nullable=False
+    )
     script = Column(Text, nullable=False)
     supports_pair_processing = Column(Boolean, nullable=False)
     supports_time_series_processing = Column(

--- a/processes/default-processes.json
+++ b/processes/default-processes.json
@@ -8,4 +8,14 @@
     "ec2_size":"N/A",
     "supports_pair_processing": false,
     "text_id":"notify_only"
+}, {
+    "name":"RTC Snap",
+    "description":"RTC Snap processing using sentinel-1 tool box",
+    "script":"hyp3-rtc-snap/src/procSentinelRTC-3.py",
+    "suffix":"N/A",
+    "database_info_required": false,
+    "ami_id":"TODO",
+    "ec2_size":"m4x.large",
+    "supports_pair_processing": false,
+    "text_id":"rtc_snap"
 }]

--- a/processes/default-processes.json
+++ b/processes/default-processes.json
@@ -4,6 +4,7 @@
     "script":"N/A",
     "suffix":"N/A",
     "database_info_required": false,
+    "output_patterns": {},
     "ami_id":"N/A",
     "ec2_size":"N/A",
     "supports_pair_processing": false,
@@ -12,6 +13,10 @@
     "name":"RTC Snap",
     "description":"RTC Snap processing using sentinel-1 tool box",
     "script":"hyp3-rtc-snap/src/procSentinelRTC-3.py",
+    "output_patterns": {
+        "archive": ["*/*_TC_G??.tif", "*/*.png", "*/*.txt"],
+        "browse": "*/*.png"
+    },
     "suffix":"N/A",
     "database_info_required": false,
     "ami_id":"TODO",


### PR DESCRIPTION
## TODO

- [x] Add queue url to lambda cloudformation template
- [x] dispatch events based on type (Email or Start)
- [x] Add start events to sqs queue
- [x] Add policy to code build role for the tests using queues
- [x] Only add jobs if the subscriptions process is enabled
- [x] Add rtc-snap process to default processes
- [x] Add `output_patterns` to process table 
- [x] Create conversion: `Job` -> `StartEvents`

## TEST
- [ ] send a job to a hyp3_process