### PR TITLE
EC2 checkout latest code version from github

### DIFF
--- a/.codebuild/codebuild.py
+++ b/.codebuild/codebuild.py
@@ -27,7 +27,7 @@ TEMPLATE_CONFIG_BUCKET = "hyp3-in-a-box"
 TEMPLATE_NAME = 'hyp3-in-a-box_US-WEST-2.json'
 
 MATURITY = os.environ["MATURITY"]
-GITHUB_HYP3_API_CLONE_TOKEN = os.environ["GITHUB_HYP3_API_CLONE_TOKEN"]
+GITHUB_ASFADMIN_CLONE_TOKEN = os.environ["GITHUB_HYP3_API_CLONE_TOKEN"]
 BUCKET_BASE_DIR = os.path.join(S3_SOURCE_BUCKET, MATURITY + "/")
 BUILD_STEP_MESSAGES = {}
 
@@ -152,7 +152,8 @@ def build():
     template_path = 'build/template.json'
     subprocess.check_call([
         "python3", "cloudformation/tropo/create_stack.py",
-        template_path, "--maturity", MATURITY
+        template_path, "--maturity", MATURITY,
+        "--clone_in_userdata", "true"
     ] + version_options
     )
     subprocess.check_call(["make", "clean", "html"], cwd="docs")
@@ -219,7 +220,7 @@ def get_latest_lambda_versions():
 def build_hyp3_api():
     print('building hyp3 api')
     hyp3_api_url = "https://{}@github.com/asfadmin/hyp3-api".format(
-        GITHUB_HYP3_API_CLONE_TOKEN
+        GITHUB_ASFADMIN_CLONE_TOKEN
     )
 
     print('cloning hyp3 api')

--- a/cloudformation/tropo/templates/ec2_userdata.py
+++ b/cloudformation/tropo/templates/ec2_userdata.py
@@ -23,7 +23,7 @@ def get_hyp3_daemon_install_script():
     the new version of the code on startup."""
 
     return """
-CLONE_TOKEN = $(aws ssm get-parameters --names /CodeBuild/GITHUB_HYP3_API_CLONE_TOKEN --output text --with-decryption | awk {'print $4'})
+CLONE_TOKEN=$(aws ssm get-parameters --names /CodeBuild/GITHUB_HYP3_API_CLONE_TOKEN --output text --with-decryption | awk {'print $4'})
 cd /tmp
 git clone --single-branch -b dev https://$CLONE_TOKEN@github.com/asfadmin/hyp3-in-a-box --depth=1
 cd hyp3-in-a-box/ec2/worker

--- a/cloudformation/tropo/templates/ec2_userdata.py
+++ b/cloudformation/tropo/templates/ec2_userdata.py
@@ -1,19 +1,21 @@
-from troposphere import Base64, Ref, Sub
+from textwrap import dedent
 
 from tropo_env import environment
+from troposphere import Base64, Ref, Sub
 
 
 def make_userdata_from_environment():
-    return """#! /bin/bash
-echo STACK_NAME=${{StackName}} > ~/env
+    return dedent("""
+        #! /bin/bash
+        echo STACK_NAME=${{StackName}} > ~/env
 
-{PullCode}
+        {PullCode}
 
-systemctl restart hyp3
-    """.format(
-        PullCode=get_hyp3_daemon_install_script() if environment.clone_in_userdata
-        else ""
-    )
+        systemctl restart hyp3
+        """.format(
+            PullCode=get_hyp3_daemon_install_script() if environment.clone_in_userdata
+            else ""
+        ))
 
 
 def get_hyp3_daemon_install_script():
@@ -21,20 +23,20 @@ def get_hyp3_daemon_install_script():
     create a new AMI when the orchestration code changes, just let the AMI pull
     the new version of the code on startup."""
 
-    return """
-CLONE_TOKEN=$(aws ssm get-parameters --names /CodeBuild/GITHUB_HYP3_API_CLONE_TOKEN --output text --with-decryption | awk {'print $4'})
-cd /tmp
-git clone --single-branch -b dev https://$CLONE_TOKEN@github.com/asfadmin/hyp3-in-a-box --depth=1
-cd hyp3-in-a-box/ec2/worker
+    return dedent("""
+        CLONE_TOKEN=$(aws ssm get-parameters --names /CodeBuild/GITHUB_HYP3_API_CLONE_TOKEN --output text --with-decryption | awk {'print $4'})
+        cd /tmp
+        git clone --single-branch -b dev https://$CLONE_TOKEN@github.com/asfadmin/hyp3-in-a-box --depth=1
+        cd hyp3-in-a-box/ec2/worker
 
-cp src/hyp3_daemon.py /opt/hyp3/
-cp hyp3.service /etc/systemd/system/
-pip install -r requirements.txt
+        cp src/hyp3_daemon.py /opt/hyp3/
+        cp hyp3.service /etc/systemd/system/
+        pip install -r requirements.txt
 
-cd /tmp/hyp3-in-a-box/processes/rtc_snap
-cp src/hyp3_handler.py /opt/hyp3/
-pip install -r requirements.txt
-"""
+        cd /tmp/hyp3-in-a-box/processes/rtc_snap
+        cp src/hyp3_handler.py /opt/hyp3/
+        pip install -r requirements.txt
+        """)
 
 
 user_data = Base64(

--- a/cloudformation/tropo/templates/ec2_userdata.py
+++ b/cloudformation/tropo/templates/ec2_userdata.py
@@ -5,15 +5,14 @@ from tropo_env import environment
 
 def make_userdata_from_environment():
     return """#! /bin/bash
-echo STACK_NAME=${StackName} > ~/env
+echo STACK_NAME=${{StackName}} > ~/env
 
 {PullCode}
 
 systemctl restart hyp3
     """.format(
         PullCode=get_hyp3_daemon_install_script() if environment.clone_in_userdata
-        else "",
-        StackName="{StackName}"
+        else ""
     )
 
 

--- a/cloudformation/tropo/templates/ec2_userdata.py
+++ b/cloudformation/tropo/templates/ec2_userdata.py
@@ -1,0 +1,15 @@
+from troposphere import Base64, Ref, Sub
+
+
+_user_data = """#! /bin/bash
+echo STACK_NAME=${StackName} > ~/env
+
+systemctl restart hyp3
+"""
+
+user_data = Base64(
+    Sub(
+        _user_data,
+        StackName=Ref('AWS::StackName')
+    )
+)

--- a/cloudformation/tropo/templates/ec2_userdata.py
+++ b/cloudformation/tropo/templates/ec2_userdata.py
@@ -1,15 +1,46 @@
 from troposphere import Base64, Ref, Sub
 
+from tropo_env import environment
 
-_user_data = """#! /bin/bash
+
+def make_userdata_from_environment():
+    return """#! /bin/bash
 echo STACK_NAME=${StackName} > ~/env
 
+{PullCode}
+
 systemctl restart hyp3
+    """.format(
+        PullCode=get_hyp3_daemon_install_script() if environment.clone_in_userdata
+        else "",
+        StackName="{StackName}"
+    )
+
+
+def get_hyp3_daemon_install_script():
+    """ This only exists for the purpose of development. Instead of needing to
+    create a new AMI when the orchestration code changes, just let the AMI pull
+    the new version of the code on startup."""
+
+    return """
+CLONE_TOKEN = $(aws ssm get-parameters --names /CodeBuild/GITHUB_HYP3_API_CLONE_TOKEN --output text --with-decryption | awk {'print $4'})
+cd /tmp
+git clone --single-branch -b dev https://$CLONE_TOKEN@github.com/asfadmin/hyp3-in-a-box --depth=1
+cd hyp3-in-a-box/ec2/worker
+
+cp src/hyp3_daemon.py /opt/hyp3/
+cp hyp3.service /etc/systemd/system/
+pip install -r requirements.txt
+
+cd /tmp/hyp3-in-a-box/processes/rtc_snap
+cp src/hyp3_handler.py /opt/hyp3/
+pip install -r requirements.txt
 """
+
 
 user_data = Base64(
     Sub(
-        _user_data,
+        make_userdata_from_environment(),
         StackName=Ref('AWS::StackName')
     )
 )

--- a/cloudformation/tropo/templates/hyp3_autoscaling_group.py
+++ b/cloudformation/tropo/templates/hyp3_autoscaling_group.py
@@ -22,8 +22,6 @@ Resources
 
 """
 
-from template import t
-from tropo_env import environment
 from troposphere import Base64, FindInMap, Ref, Sub
 from troposphere.autoscaling import (
     AutoScalingGroup,
@@ -35,6 +33,10 @@ from troposphere.autoscaling import (
 )
 from troposphere.ec2 import SecurityGroup, SecurityGroupRule
 
+from template import t
+from tropo_env import environment
+
+from .ec2_userdata import user_data
 from .hyp3_keypairname_param import keyname
 from .hyp3_vpc import get_public_subnets, hyp3_vpc
 from .utils import get_map
@@ -67,11 +69,6 @@ security_group = t.add_resource(SecurityGroup(
     ]
 ))
 
-user_data = """#! /bin/bash
-echo STACK_NAME=${StackName} > ~/env
-
-systemctl restart hyp3
-"""
 launch_config = t.add_resource(LaunchConfiguration(
     "Hyp3LaunchConfiguration",
     ImageId=FindInMap(
@@ -81,12 +78,7 @@ launch_config = t.add_resource(LaunchConfiguration(
     KeyName=Ref(keyname),
     SecurityGroups=[Ref(security_group)],
     InstanceType="m1.small",
-    UserData=Base64(
-        Sub(
-            user_data,
-            StackName=Ref('AWS::StackName')
-        )
-    )
+    UserData=user_data
 ))
 
 processing_group = t.add_resource(AutoScalingGroup(

--- a/cloudformation/tropo/tropo_env.py
+++ b/cloudformation/tropo/tropo_env.py
@@ -22,6 +22,7 @@ class Environment:
 
         self.use_name_parameters = True
         self.should_create_db = True
+        self.clone_in_userdata = False
 
     def get_variables(self):
         return [

--- a/processes/rtc_snap/requirements.txt
+++ b/processes/rtc_snap/requirements.txt
@@ -1,3 +1,4 @@
 -i https://pypi.org/simple
 ./../../modules/hyp3_events
 ./../../modules/hyp3_process
+asf_granule_util


### PR DESCRIPTION
Added script in userdata for installing latest version of hyp3 code from github. This will only be enabled if you pass in the `--clone_in_userdata` flag of create_stack.py. This should make development easier.

Not sure if the install script works correctly because I don't know where stuff is installed to on the instances and I'm not sure if this catches all the pieces.