### PR TITLE
Use keyword args when creating jobs to schedule

### DIFF
--- a/lambdas/scheduler/src/schedule/hyp3_jobs.py
+++ b/lambdas/scheduler/src/schedule/hyp3_jobs.py
@@ -43,7 +43,12 @@ def get_jobs_for(granule: NewGranuleEvent, db) -> List[Job]:
     processes = get_processes(db)
 
     return [
-        Job(sub, processes[sub.process_id], users[sub.user_id], granule)
+        Job(
+            sub=sub,
+            process=processes[sub.process_id],
+            user=users[sub.user_id],
+            granule=granule
+        )
         for sub in subs
     ]
 

--- a/lambdas/scheduler/tests/test_scheduler.py
+++ b/lambdas/scheduler/tests/test_scheduler.py
@@ -21,7 +21,6 @@ def test_scheduler_main(sns_mock, sqs_mock, testing_granules):
 @skip_if_creds_not_available
 def test_scheduler(granule_events):
     jobs = schedule.hyp3_jobs(granule_events)
-
     assert isinstance(jobs, list)
 
     for job in jobs:

--- a/processes/rtc_snap/src/hyp3_handler.py
+++ b/processes/rtc_snap/src/hyp3_handler.py
@@ -1,4 +1,5 @@
 import subprocess
+from typing import Dict
 
 import asf_granule_util as gu
 
@@ -6,7 +7,7 @@ import asf_granule_util as gu
 def handler(
     granule_name: str,
     working_dir: str,
-    earthdata_creds: str,
+    earthdata_creds: Dict[str, str],
     script_path: str
 ) -> None:
     print('processing rtc product')


### PR DESCRIPTION
- This is so changing the argument ordering in the Job class doesn't matter
- Also fixed type annotation in handler file

## NEXT

- improve scheduler testing to catch this error